### PR TITLE
Bugfix 137

### DIFF
--- a/R/ExtractData_ClimateDownscaling.R
+++ b/R/ExtractData_ClimateDownscaling.R
@@ -2889,7 +2889,8 @@ ExtractClimateChangeScenarios <- function(climDB_metas, SFSW2_prj_meta, SFSW2_pr
   #   - GriddedDailyWeatherFromNCEPCFSR_Global
   setup_SFSW2_cluster(opt_parallel,
     dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]],
-    verbose = opt_verbosity[["verbose"]])
+    verbose = opt_verbosity[["verbose"]],
+    print.debug = opt_verbosity[["print.debug"]])
   on.exit(exit_SFSW2_cluster(verbose = opt_verbosity[["verbose"]]),
     add = TRUE)
   on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],

--- a/R/ExtractData_MeanMonthlyClimate.R
+++ b/R/ExtractData_MeanMonthlyClimate.R
@@ -259,7 +259,8 @@ do_ExtractSkyDataFromNCEPCFSR_Global <- function(MMC, SWRunInformation, SFSW2_pr
   #--- SET UP PARALLELIZATION
   setup_SFSW2_cluster(opt_parallel,
     dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]],
-    verbose = opt_verbosity[["verbose"]])
+    verbose = opt_verbosity[["verbose"]],
+    print.debug = opt_verbosity[["print.debug"]])
   on.exit(exit_SFSW2_cluster(verbose = opt_verbosity[["verbose"]]),
     add = TRUE)
   on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],

--- a/R/ExtractData_Soils.R
+++ b/R/ExtractData_Soils.R
@@ -746,7 +746,8 @@ ExtractData_Soils <- function(exinfo, SFSW2_prj_meta, SFSW2_prj_inputs, opt_para
   #--- SET UP PARALLELIZATION
   setup_SFSW2_cluster(opt_parallel,
     dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]],
-    verbose = opt_verbosity[["verbose"]])
+    verbose = opt_verbosity[["verbose"]],
+    print.debug = opt_verbosity[["print.debug"]])
   on.exit(exit_SFSW2_cluster(verbose = opt_verbosity[["verbose"]]),
     add = TRUE)
   on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],

--- a/R/OutputDatabase.R
+++ b/R/OutputDatabase.R
@@ -896,7 +896,8 @@ check_outputDB_completeness <- function(SFSW2_prj_meta, opt_parallel, opt_behave
   #--- SET UP PARALLELIZATION
   setup_SFSW2_cluster(opt_parallel,
     dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]],
-    verbose = opt_verbosity[["verbose"]])
+    verbose = opt_verbosity[["verbose"]],
+    print.debug = opt_verbosity[["print.debug"]])
   on.exit(exit_SFSW2_cluster(verbose = opt_verbosity[["verbose"]]),
     add = TRUE)
   on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],

--- a/R/Parallel.R
+++ b/R/Parallel.R
@@ -96,6 +96,46 @@ export_objects_to_workers <- function(obj_env,
   success
 }
 
+#' This is for workers
+set_glovar <- function(x, value) {
+  # The environment 'SFSW2_glovars' is the one of the package copy on the workers!
+  assign(x = x, value = value, envir = SFSW2_glovars)
+}
+
+export_parallel_glovars <- function(verbose = FALSE) {
+  if (SFSW2_glovars[["p_has"]]) {
+    if (verbose) {
+      t1 <- Sys.time()
+      temp_call <- shQuote(match.call()[1])
+      print(paste0("rSFSW2's ", temp_call, ": started at ", t1))
+
+      on.exit({print(paste0("rSFSW2's ", temp_call, ": ended after ",
+        round(difftime(Sys.time(), t1, units = "secs"), 2), " s")); cat("\n")}, add = TRUE)
+    }
+
+    p_varnames <- grep("p_", ls(envir = SFSW2_glovars), value = TRUE)
+
+    if (identical(SFSW2_glovars[["p_type"]], "socket")) {
+      for (x in p_varnames) {
+        parallel::clusterCall(SFSW2_glovars[["p_cl"]], fun = set_glovar, x = x,
+          value = SFSW2_glovars[[x]])
+      }
+
+    } else if (identical(SFSW2_glovars[["p_type"]], "mpi")) {
+      # We have to rename functions locally (and export to workers):
+      # 'do.call' (as called by 'mpi.remote.exec'/'mpi.bcast.cmd' of Rmpi v0.6.6) does not
+      # handle 'what' arguments of a character string format "pkg::fun" because "pkg::fun"
+      # is not the name of a function
+      .set_glovar <- function(x, value, verbose = FALSE) set_glovar(x, value, verbose)
+      Rmpi::mpi.bcast.Robj2slave(.set_glovar)
+      for (x in p_varnames) {
+        Rmpi::mpi.bcast.cmd(cmd = .set_glovar, x = x, value = SFSW2_glovars[[x]])
+      }
+    }
+  }
+
+  invisible(TRUE)
+}
 
 
 
@@ -284,7 +324,9 @@ init_SFSW2_cluster <- function() {
 
 #' Set-up a parallel cluster to be used for a rSFSW2 simulation project
 #' @export
-setup_SFSW2_cluster <- function(opt_parallel, dir_out, verbose = FALSE) {
+setup_SFSW2_cluster <- function(opt_parallel, dir_out, verbose = FALSE,
+  print.debug = FALSE) {
+
   if (!SFSW2_glovars[["p_has"]]) {
     init_SFSW2_cluster()
   }
@@ -365,7 +407,17 @@ setup_SFSW2_cluster <- function(opt_parallel, dir_out, verbose = FALSE) {
 
     SFSW2_glovars[["p_has"]] <- !is.null(SFSW2_glovars[["p_cl"]]) &&
       SFSW2_glovars[["p_workersN"]] > 1
+
+    if (print.debug) {
+      temp <- sapply(grep("p_", ls(envir = SFSW2_glovars), value = TRUE),
+        function(x) paste(shQuote(x), "=", paste(SFSW2_glovars[[x]], collapse = " / ")))
+      temp <- paste(temp, collapse = "; ")
+
+      print(paste("Workers set up with:", temp))
+    }
   }
+
+  export_parallel_glovars(verbose = print.debug)
 
   invisible(TRUE)
 }

--- a/R/Parallel.R
+++ b/R/Parallel.R
@@ -126,7 +126,7 @@ export_parallel_glovars <- function(verbose = FALSE) {
       # 'do.call' (as called by 'mpi.remote.exec'/'mpi.bcast.cmd' of Rmpi v0.6.6) does not
       # handle 'what' arguments of a character string format "pkg::fun" because "pkg::fun"
       # is not the name of a function
-      .set_glovar <- function(x, value, verbose = FALSE) set_glovar(x, value, verbose)
+      .set_glovar <- function(x, value) set_glovar(x, value)
       Rmpi::mpi.bcast.Robj2slave(.set_glovar)
       for (x in p_varnames) {
         Rmpi::mpi.bcast.cmd(cmd = .set_glovar, x = x, value = SFSW2_glovars[[x]])

--- a/R/Simulation_Project.R
+++ b/R/Simulation_Project.R
@@ -719,7 +719,8 @@ simulate_SOILWAT2_experiment <- function(actions, SFSW2_prj_meta, SFSW2_prj_inpu
   #   - ensembles
   setup_SFSW2_cluster(opt_parallel,
     dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]],
-    verbose = opt_verbosity[["verbose"]])
+    verbose = opt_verbosity[["verbose"]],
+    print.debug = opt_verbosity[["print.debug"]])
   on.exit(exit_SFSW2_cluster(verbose = opt_verbosity[["verbose"]]),
     add = TRUE)
   on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],

--- a/R/Simulation_Run.R
+++ b/R/Simulation_Run.R
@@ -108,8 +108,10 @@ do_OneSite <- function(i_sim, i_SWRunInformation, i_sw_input_soillayers,
   set_RNG_stream(seed = rng_specs[["seeds_runN"]][[it_site(i_sim, sim_size[["runsN_master"]])]])
 
   if (opt_verbosity[["print.debug"]] && identical(fid, 0L)) {
-    temp <- paste(sapply(grep("p_", ls(envir = SFSW2_glovars), value = TRUE), function(x)
-      paste(shQuote(x), "=", SFSW2_glovars[[x]])), collapse = " / ")
+    temp <- sapply(grep("p_", ls(envir = SFSW2_glovars), value = TRUE),
+      function(x) paste(shQuote(x), "=", paste(SFSW2_glovars[[x]], collapse = " / ")))
+    temp <- paste(temp, collapse = "; ")
+
     print(paste0(tag_funid, ": worker ID is 0 with global variables: ", temp))
   }
 
@@ -4713,7 +4715,7 @@ do_OneSite <- function(i_sim, i_SWRunInformation, i_sw_input_soillayers,
     }
 
   } else {
-    print(tag_funid, ": unsuccessful after ", delta.do_OneSite, " ",
+    print(paste0(tag_funid, ": unsuccessful after ", delta.do_OneSite, " ",
       units(delta.do_OneSite), " with status of tasks = "))
     print(unlist(sapply(tasks, table)))
   }

--- a/R/WeatherDB.R
+++ b/R/WeatherDB.R
@@ -174,7 +174,7 @@ make_dbW <- function(SFSW2_prj_meta, SWRunInformation, opt_parallel, opt_chunks,
       length(ids_Livneh_extraction) > 0) {
       #--- Set up parallelization
       setup_SFSW2_cluster(opt_parallel,
-        dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]], verbose)
+        dir_out = SFSW2_prj_meta[["project_paths"]][["dir_prj"]], verbose = verbose)
       on.exit(exit_SFSW2_cluster(verbose), add = TRUE)
 
       on.exit(set_full_RNG(SFSW2_prj_meta[["rng_specs"]][["seed_prev"]],


### PR DESCRIPTION
- function 'export_parallel_glovars' exports values of local global package parallel-framework  ariables to the package copy on  orkers. For this it uses the function 'set_glovar' which allows assigning the exported value to the corresponding elements in the environment of the package copy on the workers.
- function 'export_parallel_glovars' is called by function 'setup_SFSW2_cluster'